### PR TITLE
added redirect to fix 404 bug

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -601,6 +601,7 @@ plugins:
          'release-notes.md': 'Latest-updates/release-notes.md'
          'requirements.md': 'Monitor-your-data/FR-Agent/More/requirements.md'
          'Getting-started/DVCloud.md' : 'index.md'
+         'Getting-started/GSCloudsetup.md' : 'Getting-started/Trial.md'
            
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
Resolved a 404 error in the documentation by implementing a redirect to the correct path. This ensures users can access the intended content without encountering broken links.