### PR TITLE
added the Eula pg to Licensing

### DIFF
--- a/docs/Admin-and-data/EULA.md
+++ b/docs/Admin-and-data/EULA.md
@@ -1,0 +1,221 @@
+THE FOLLOWING EULA APPLIES TO FUSIONREACTOR VERSIONS 7, 8, 9, 10, 11 AND 12 AND THEIR MINOR/MICRO UPDATES ONLY.
+
+!!! warning "IMPORTANT"
+    CAREFULLY READ THE FOLLOWING LICENSE AGREEMENT. THIS **END USER LICENSE AGREEMENT(“EULA”)** IS A LEGAL AGREEMENT BETWEEN YOU (EITHER AN INDIVIDUAL OR, IF PURCHASED OR OTHERWISE ACQUIRED BY OR FOR AN ENTITY, AN ENTITY) AND **INTERGRAL**. YOU ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS AGREEMENT BY SELECTING THE “ACCEPT” OPTION OR DOWNLOADING THE SOFTWARE OR BY INSTALLING, USING, OR COPYING THE SOFTWARE. IF YOU DO NOT AGREE TO BE BOUND BY THESE TERMS THEN DO NOT INSTALL, COPY, DOWNLOAD OR OTHERWISE
+    USE THE SOFTWARE. THIS **EULA** SHALL APPLY ONLY TO THE SOFTWARE SUPPLIED BY **INTERGRAL** HEREWITH REGARDLESS OF WHETHER OTHER SOFTWARE IS REFERRED TO OR DESCRIBED HEREIN.
+
+## Definitions
+
+| Term                  | Definition                                                                                                 |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **INTERGRAL**         | **INTERGRAL Information Solutions GmbH** and its licensors, if any.                                            |
+| **Developer Version** | A version of the Software used only for design, development, and evaluation.                               |
+| **Free Version**      | A limited-feature version that may stop operating after a set time.                                        |
+| **Trial Version**     | A version for review and evaluation that may have limited features and time restrictions.                  |
+| **Full Version**      | A version that is not Developer, Trial, or Free.                                                           |
+| **Accessible Code**   | Unprotected and accessible source code.                                                                    |
+| **Protected Code**    | Any source code that is protected against access by **INTERGRAL** or a third party and is not accessible under this EULA.                                                                |
+| **Fees**              | All fees and expenses payable by the Licensee to **INTERGRAL** in acquiring the Software and as applicable any Subscription or User Licenses.                             |
+| **Software**          | The **INTERGRAL** software and third party software programs, in each case, supplied by **INTERGRAL** together with this EULA, including its Accessible Code and Protected Code and any corresponding documentation, online or electronic  documentation, printed materials, and associated media. Any updates to such Software that you are entitled to receive and that have been provided to you by **INTERGRAL** shall also mean Software for purposes of this Agreement. |
+
+
+## License Grant
+
+The Software is subject to the terms and conditions of this Agreement. **INTERGRAL** hereby grants, and you accept, the right and license to install and use the Software provided that you do not use, copy, or install the Software on more than the number of computers permitted by license, or permit the use, copying, or installation by more users on more computers than the number permitted by the license.
+
+You may make one copy of the Software in machine-readable form solely for backup purposes. You must reproduce on any such copy all copyright notices and any other proprietary legends on the original copy of the Software.
+
+The Software is protected by copyright laws and international copyright treaties, as well as other intellectual property laws and treaties. **INTERGRAL** reserves all intellectual property rights, including copyrights and trademark rights. Your license rights under this EULA are non-exclusive.
+
+## License Restrictions
+
+### Restrictions on Use
+
+Other than as expressly set forth above, you may not make or distribute copies of the Software, or electronically transfer the Software from one computer to another or over a network.
+
+You may not decompile, “reverse-engineer”, disassemble, or otherwise attempt to derive the source code for the Software.
+
+You may not use the database portion of the Software in connection with any software other than the Software.
+
+You shall not: <br>
+**(A)** in the aggregate, install or use more than one copy of the Trial Version of the Software, <br>
+**(B)** download the Trial Version of the Software under more than one username, <br>
+**(C)** alter the contents of a hard drive or computer system to enable the use of the Trial Version of the Software for an aggregate period in excess of the trial period for one license to such Trial Version, <br>
+**(D)** disclose the results of software performance benchmarks obtained using the Trial Version to any third party without **INTERGRAL’s** prior written consent, <br>
+**(E)** use the Trial Version for any application deployment or ultimate production purpose, or <br>
+**(F)** use the Trial Version of the Software for a purpose other than the sole purpose of determining whether to purchase a license to a Full Version or a Developer Version of the Software; <br>
+
+**Provided, however**, notwithstanding the foregoing, you are **strictly prohibited** from installing or using the Trial Version of the Software for any **commercial training purpose**.
+
+
+You shall not use the Developer Version for any application deployment in a **live**, **stand-by production**, or **staging** environment — in each case including, without limitation, any environment accessed by application end-users, including but not limited to:
+
+* servers,
+* workstations,
+* kiosks, and
+* mobile computers.
+
+You shall not use the Software to develop any application **having the same primary function** as the Software.
+
+
+Subject to the terms and conditions of this Agreement, you must at all times ensure that the Software is **not used** for:
+
+* rental,
+* timesharing,
+* subscription service,
+* hosting,
+* outsourcing, or
+* as part of a service or consulting practice to a third party,
+
+**without first obtaining the express written consent of *INTERGRAL***.
+
+
+### Restrictions on Alteration
+
+You may not alter, merge, adapt, translate or modify the Software or create any derivative work of the Software or its accompanying documentation. Derivative works include but are not limited to translations. You may not alter any files or libraries in any portion of the Software. You may not reproduce the database portion or create any tables or reports relating to the database portion.
+
+### Restrictions on Copying
+
+You may not copy any part of the Software except to the extent that licensed use inherently demands the creation of a temporary copy stored in computer memory and not permanently affixed on storage medium. You may make one archival copy which must be stored on a medium other than a computer hard drive.
+
+### Restrictions on Transfer
+
+Without first obtaining the express written consent of **INTERGRAL**, you may not assign your rights and obligations under this Agreement, or redistribute, encumber, sell, rent, lease, sublicense, or otherwise transfer your rights to the Software. You may not sell or transfer any Software purchased under a volume discount. You may not sell or transfer any Trial Version or Free Version of the Software.
+
+### Permitted Fixes
+
+Notwithstanding anything else in this EULA but subject to the terms and conditions contained herein, the Licensee is permitted to modify the Accessible Code in the Software to develop bug fixes, customizations or additional features solely for their internal purposes of using the Software.
+
+### Upgrades
+
+If this copy of the Software is an upgrade from an earlier version of the Software, it is provided to you on a license exchange basis. You agree by your installation and use of this copy of the Software to voluntarily terminate your EULA with respect to such prior license to the Software and that you will not continue to install or use such prior license of the Software or transfer it to another person or entity.
+
+### Ownership
+
+The foregoing grants of rights give you limited license to use the Software. Except as expressly provided in this Agreement, **INTERGRAL** remain the owner of all right, title and interest in the Software. All rights not specifically granted in this EULA are reserved by **INTERGRAL**.
+
+### Fees
+
+The Licensee must pay all Fees by their due date. Failure to pay Fees by the due date will result in the immediate termination of the licenses granted under this EULA.
+
+You are responsible for reviewing the Software’s website for changes in the fees, including, but not limited to, subscription fees and payment terms.
+
+### Termination 
+
+Without prejudice to any other rights and in addition to any other termination rights in this EULA, **INTERGRAL** may terminate this EULA if the Licensee fails to comply with the terms and conditions of this EULA. Immediately upon termination of a license granted under this EULA, the Licensee must at its own cost remove all copies of the Software including all Accessible Code from its computer systems and provide **INTERGRAL** with written certification that it has destroyed all copies of the Software including all Accessible Code in its possession, custody or control.
+
+## Limited Warranty and Disclaimer 
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW IN THE JURISDICTION IN WHICH THE SOFTWARE IS PROVIDED, **INTERGRAL** PROVIDES THE SOFTWARE AS IS AND WITH ALL FAULTS, AND EXCEPT OTHERWISE EXPRESSLY CONTAINED IN THE EULA, HEREBY DISCLAIM ALL OTHER WARRANTIES AND CONDITIONS, WHETHER EXPRESS, IMPLIED OR STATUTORY.
+
+**INTERGRAL** MAKES NO WARRANTY THAT THE SOFTWARE WILL MEET YOUR REQUIREMENTS OR OPERATE UNDER YOUR SPECIFIC CONDITIONS OF USE. **INTERGRAL** MAKES NO WARRANTY THAT OPERATION OF THE SOFTWARE WILL BE SECURE, ERROR FREE, OR FREE FROM INTERRUPTION. YOU MUST DETERMINE WHETHER THE SOFTWARE SUFFICIENTLY MEETS YOUR REQUIREMENTS FOR SECURITY AND UNINTERRUPTABILITY. YOU BEAR SOLE RESPONSIBILITY AND ALL LIABILITY FOR ANY LOSS INCURRED DUE TO FAILURE OF THE SOFTWARE TO MEET YOUR REQUIREMENTS. **INTERGRAL** WILL NOT, UNDER ANY CIRCUMSTANCES, BE RESPONSIBLE OR LIABLE FOR THE LOSS OF DATA ON ANY COMPUTER OR INFORMATION STORAGE DEVICE. **INTERGRAL** DISCLAIM ALL OTHER WARRANTIES AND REPRESENTATIONS, WHETHER EXPRESS, IMPLIED, OR OTHERWISE, INCLUDING THE WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE IS NOT DESIGNED, INTENDED OR LICENSED FOR USE IN HAZARDOUS ENVIRONMENTS REQUIRING FAIL- SAFE CONTROLS, INCLUDING WITHOUT LIMITATION, THE DESIGN, CONSTRUCTION, MAINTENANCE OR OPERATION OF NUCLEAR FACILITIES, AIRCRAFT NAVIGATION OR COMMUNICATION SYSTEMS, AIR TRAFFIC CONTROL, AND LIFE SUPPORT OR WEAPONS SYSTEMS. **INTERGRAL** SPECIFICALLY DISCLAIMS ANY EXPRESS OR IMPLIED WARRANTY OF FITNESS FOR SUCH PURPOSES.
+
+**INTERGRAL** PROVIDES NO REMEDIES OR WARRANTIES, WHETHER EXPRESS OR IMPLIED, FOR THE TRIAL VERSION AND THE FREE VERSION OF THE SOFTWARE. THE TRIAL VERSION AND THE FREE VERSION OF THE SOFTWARE ARE PROVIDED “AS IS” AND WITH ALL FAULTS AND HEREBY DISCLAIM ALL OTHER WARRANTIES AND CONDITIONS, WHETHER EXPRESS, IMPLIED OR STATUTORY.
+
+UNLESS OTHERWISE EXPLICITLY AGREED TO IN WRITING BY **INTERGRAL**, **INTERGRAL** MAKES NO OTHER WARRANTIES, EXPRESS OR IMPLIED, IN FACT OR IN LAW, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE OTHER THAN AS SET FORTH IN THIS AGREEMENT OR IN THE LIMITED WARRANTY DOCUMENTS PROVIDED WITH THE SOFTWARE.
+
+IF APPLICABLE LAW REQUIRES ANY WARRANTIES WITH RESPECT TO THE SOFTWARE, ALL SUCH WARRANTIES ARE LIMITED IN DURATION TO THIRTY (30) DAYS FROM THE DATE OF DELIVERY.
+
+NO ORAL OR WRITTEN INFORMATION OR ADVICE GIVEN BY **INTERGRAL**, ITS DEALERS, DISTRIBUTORS, AGENTS OR EMPLOYEES SHALL CREATE A WARRANTY OR IN ANY WAY INCREASE THE SCOPE OF ANY WARRANTY PROVIDED HEREIN.
+
+## Limited Remedy
+
+YOUR REMEDY FOR A BREACH OF THIS AGREEMENT OR OF ANY WARRANTY INCLUDED IN THIS AGREEMENT IS THE CORRECTION OR REPLACEMENT OF THE SOFTWARE. SELECTION OF WHETHER TO CORRECT OR REPLACE SHALL BE SOLELY AT THE DISCRETION OF **INTERGRAL**. **INTERGRAL** RESERVES THE RIGHT TO SUBSTITUTE A FUNCTIONALLY EQUIVALENT COPY OF THE SOFTWARE AS A REPLACEMENT. IF **INTERGRAL** IS UNABLE TO PROVIDE A REPLACEMENT OR SUBSTITUTE SOFTWARE OR CORRECTIONS TO THE SOFTWARE, YOUR SOLE ALTERNATE REMEDY SHALL BE A REFUND OF THE PURCHASE PRICE FOR THE SOFTWARE EXCLUSIVE OF ANY COSTS FOR SHIPPING AND HANDLING.
+
+ANY CLAIM MUST BE MADE WITHIN THE APPLICABLE WARRANTY PERIOD. ALL WARRANTIES COVER ONLY DEFECTS ARISING UNDER NORMAL USE AND DO NOT INCLUDE MALFUNCTIONS OR FAILURE RESULTING FROM MISUSE, ABUSE, NEGLECT, ALTERATION, MISAPPLICATION, PROBLEMS WITH DATA NETWORKS, PROBLEMS WITH ELECTRICAL POWER, ACTS OF NATURE, UNUSUAL TEMPERATURES OR HUMIDITY, IMPROPER INSTALLATION, DAMAGE TO MEDIA OR DAMAGE DETERMINED BY **INTERGRAL** TO HAVE BEEN CAUSED BY YOU. ALL LIMITED WARRANTIES ON THE SOFTWARE ARE GRANTED ONLY TO YOU AND ARE NON- TRANSFERABLE.
+
+YOU AGREE TO INDEMNIFY AND HOLD **INTERGRAL** HARMLESS FROM ALL CLAIMS, JUDGMENTS, LIABILITIES, EXPENSES, OR COSTS ARISING FROM YOUR BREACH OF THIS AGREEMENT AND/OR ACTS OR OMISSIONS. THIS REMEDY IS THE SOLE AND EXCLUSIVE REMEDY AVAILABLE TO YOU FOR BREACH OF EXPRESS OR IMPLIED WARRANTIES WITH RESPECT TO THE SOFTWARE AND RELATED DOCUMENTATION.
+
+## Limitation of Liability
+
+UNDER NO CIRCUMSTANCES SHALL **INTERGRAL**, ITS DIRECTORS, OFFICERS, EMPLOYEES AND AGENTS BE LIABLE TO YOU OR ANY OTHER PARTY FOR INDIRECT, CONSEQUENTIAL, SPECIAL, INCIDENTAL, PUNITIVE, OR EXEMPLARY DAMAGES OF ANY KIND (INCLUDING LOST REVENUES OR PROFITS OR LOSS OF BUSINESS) RESULTING FROM THIS AGREEMENT, OR FROM THE FURNISHING, PERFORMANCE, INSTALLATION, OR USE OF THE SOFTWARE, HETHER DUE TO A BREACH OF CONTRACT, BREACH OF WARRANTY, OR THE NEGLIGENCE OF **INTERGRAL** OR ANY OTHER PARTY, EVEN IF **INTERGRAL** IS ADVISED BEFOREHAND OF THE POSSIBILITY OF SUCH DAMAGES. TO THE EXTENT THAT THE APPLICABLE JURISDICTION LIMITS **INTERGRAL’S** ABILITY TO DISCLAIM ANY IMPLIED WARRANTIES, THIS DISCLAIMER SHALL BE EFFECTIVE TO THE MAXIMUM EXTENT PERMITTED. **INTERGRAL’S** LIABILITY UNDER THIS AGREEMENT WILL NOT, IN ANY EVENT, EXCEED THE LICENSE FEES YOU PAID FOR THE SOFTWARE, IF ANY.
+
+### Indemnification
+
+To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless **INTERGRAL**, its directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys fees) arising out of or accruing from: <br>
+**(a)** your use of the Software, <br>
+**(b)** any application you develop on the Software that infringes any copyright, trademark, trade secret, trade dress, patent or other intellectual property right of any person or defames any person or violates their rights of publicity or privacy, and <br>
+**(c)** any non- compliance by you with this License Agreement.
+
+### Confidentiality
+
+The Software contains trade secrets and proprietary know-how that belong to **INTERGRAL** and it is being made available to you in strict confidence. ANY USE OR DISCLOSURE OF THE SOFTWARE, OR OF ITS ALGORITHMS, PROTOCOLS OR INTERFACES, OTHER THAN IN STRICT ACCORDANCE WITH THIS LICENSE AGREEMENT, MAY BE ACTIONABLE AS A VIOLATION OF OUR TRADE SECRET RIGHTS.
+
+### Publicity Rights
+
+Licensee grants **INTERGRAL** the right to include Licensee as a customer in Software promotional material. Licensee can deny **INTERGRAL** this right at any time by submitting a written request via email to SALES@**INTERGRAL**.COM, requesting to be excluded from Software promotional material. Requests ade after purchasing may take thirty (30) calendar days to process.
+
+### Use of Decompiler
+
+The Software includes decompiling functionality (“Decompiler”) that enables reproducing source code from the original binary code. You hereby acknowledge that the binary code and source code may be protected by copyright, trademark and other laws which may prohibit you from decompiling them and/or using
+
+Decompiler. Before using Decompiler, you should make sure that the decompilation is not prohibited by any applicable license  agreement of the application and/or original binary code (except to the extent that you may be expressly permitted under applicable law) or that you have obtained permission to decompile the code from the copyright owner. Using Decompiler is entirely optional. **INTERGRAL** does neither encourage nor condone
+the use of the Decompiler and disclaims any liability for your  use of Decompiler in violation of applicable laws.
+
+### Use of Debugger
+
+The Software includes debugging functionality (“Debugger”) that enables debugging programs that may contain binary code, source code and intellectual property protected by copyright, trademark, patent and other laws which may prohibit you from debugging them and/or using Debugger. Before using debugger,you should make sure that debugging is not prohibited by any applicable license agreement of the program and/or original binary code (except to the extent that you may be expressly permitted under applicable law), or by other protecting laws, or that you have obtained permission to debug the program from all legal protection owner(s). Using Debugger is entirely optional.  **INTERGRAL** does neither encourage nor condone the use of the Debugger and disclaims any liability for your use of Debugger in violation of applicable laws.
+
+### FusionReactor Cloud Service
+
+Use of the FusionReactor Cloud Service is governed by the terms and conditions that accompanies or is included with the FusionReactor Cloud Service. By accepting this EULA, you are also accepting the additional terms and conditions when using the Software with the FusionReactor Cloud Service.
+
+### Third Party Software
+
+Any software provided along with the Software that is associated with a separate license agreement is licensed to you under the terms of that license agreement. This license does not apply to those portions of the Software. Copies of these third party licenses are included in all copies of the Software. By accepting this EULA, you are also accepting the additional terms.
+
+## Restrictions 
+
+**United States**: If the Software is acquired by the Licensee in the United States, the Licensee acknowledges: <br>
+**(a)** the Software is subject to U.S. export jurisdiction and agrees to comply with all applicable international and national laws that apply to the Software, including the U.S. Export Administration Regulations, as well as end-user, end- use, and destination restrictions issued by U.S. and other governments and notwithstanding the above; and <br>
+**(b)** the provisions of the USA Uniform Computer Information Transaction Act do not apply to this EULA.
+
+**CONSENT TO COLLECT AND USE OF PERSONAL INFORMATION** <br>
+You acknowledge and agree that we may collect, transfer, process and store certain information (“Information”) collected by the Software, including but not limited to: <br>
+
+**(i)** IP addresses of the system on which Software is installed; <br>
+**(ii)** MAC Addresses of the system on which Software is installed; <br>
+**(iii)** Email addresses configured for use with the Software; <br>
+**(iv)** Information about the system on which Software is installed, for example: OS version; processor architecture; operational status;<br>
+**(v)** Information about the application software on which Software is installed, for example: application software version; application software configuration; JVM configuration; operational status;<br>
+**(vi)** Information regarding how you are using the Software, for example: version of the Software; statistical information about the Software; configuration of the Software.<br>
+
+**INTERGRAL** and its Data Processors may use Information subject to applicable laws in order to license and bill for the Software and services, improve its products and services or to provide products or services (if any) to you. Such uses include, but are not limited to: <br>
+
+**(a)** licensing and billing for the Software and services usage; <br>
+**(b)** administering the functionality of the Software and services; <br>
+**(c)** to improve, update or upgrade the Software and services; <br>
+**(d)** improving, developing and enhancing the products and services of **INTERGRAL**; <br>
+**(e)** provide product support, products and services to you; <br>
+**(f)** complying with applicable laws or regulations. <br>
+
+**INTERGRAL** will not intentionally use Information to personally identify the owner or user of the Software without your knowledge or consent.
+
+Any use of Information will be in accordance with the privacy policies of **INTERGRAL**.
+
+Info+mation may be processed, stored or transferred to **INTERGRAL** and its Data Processors which may be located in countries outside of your country of residence.
+
+**INTERGRAL** will use reasonable efforts to take appropriate technical and organizational measures to prevent unauthorized access to or disclosure of Information, but does not warrant it will eliminate all risk of misuse of Information.
+
+**General**: The export of the Software from the country of original purchase may be subject to control or restriction by applicable local law. Licensee is solely responsible for determining the existence and application of any such law to any proposed export and for obtaining any needed authorization. Licensee agrees not to export the Software from any country in violation of applicable legal restrictions on such export.
+
+### Governing Law, Jurisdiction and Costs
+
+This EULA is governed by the laws of Baden-Wuerttemberg, Germany without regard to Baden-Wuerttemberg’s conflict or choice of law provisions. Exclusive jurisdiction and place of performance is Boeblingen, Germany, as long as permitted by applicable law. The United Nations Convention for the International Sale of Goods shall not apply.
+
+### Changes to the License Agreement
+
+**INTERGRAL** may make changes to the License Agreement as it distributes new versions of the Software. When these changes are made, **INTERGRAL** will make a new version of the License Agreement available on the website where the Software is made available.
+
+### Entire Agreement and Severability
+
+Thiss EULA is the entire agreement between **INTERGRAL** and you, and supersedes all prior or contemporaneous agreements or understandings, whether oral or written any other communications or advertising with respect to the Software; this EULA may be modified only by written agreement signed by authorized representatives of both you and **INTERGRA**. No **INTERGRAL** dealer or agent is authorized to make any amendment to this EULA.
+
+If any provision of this EULA shall be held to be invalid or unenforceable, the remainder of this EULA shall remain in full force and effect and an enforceable term will be substituted reflecting our intent as closely as possible. All rights not expressly granted in this agreement are retained by **INTERGRAL**. To the extent any express or implied restrictions are not permitted by applicable laws, these express or implied restrictions shall remain in force and effect to the maximum extent permitted by such applicable laws. The failure or delay of **INTERGRAL** to exercise any of its rights under this EULA or upon any breach of this EULA shall not be deemed a waiver of those rights or of the breach. You agree that any varying or additional terms contained in any purchase order or other written notification or document issued by you in relation to the Software licensed hereunder shall be of no effect.
+
+**INTERGRAL** and other trademarks contained in the Software are trademarks or registered trademarks of **INTERGRAL** Information Solutions GmbH. Third party trademarks, trade names, product names and logos may be the trademarks or registered trademarks of their respective owners. You may not remove or alter any trademark, trade names, product names, logo, copyright or other proprietary notices, legends, symbols or labels in the Software.
+
+This EULA does not authorize you to use **INTERGRAL’s** or its licensors’ names or any of their respective trademarks.
+
+!!! note
+    The latest version of the EULA is available [here](https://fusion-reactor.com/eula-intergral-software-end-user-license-agreement/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -453,6 +453,7 @@ nav:
         - Manual activation: Admin-and-data/Licensing/Manual-Activation.md
         - Static endpoints: Admin-and-data/Licensing/Static-Licensing-Endpoints.md
         - Troubleshooting: Admin-and-data/Licensing/Troubleshooting.md
+        - EULA: Admin-and-data/EULA.md
      - Security: Admin-and-data/security.md
      - Terms of Service: Admin-and-data/tos.md
      - Third Party Licenses: 


### PR DESCRIPTION
Added the full text of the INTERGRAL End User License Agreement (EULA) into the repository to support version tracking and archival for distributed builds.

Additionally, it includes a reference to the latest EULA hosted on our website to clarify that the most current and legally binding version is always online.