### PR TITLE
Fix broken links across docs

### DIFF
--- a/docs/Admin-and-data/Billing/Cloud/overview.md
+++ b/docs/Admin-and-data/Billing/Cloud/overview.md
@@ -279,11 +279,11 @@ Alongside each data source is a graph that provides further information on your 
 To control your usage and spending costs it is possible to create an alert to fire if you exceed the allowed usage. 
 
 !!! info "Learn more"
-    [Create a check](/Data-insights/Features/alerting/#create-a-check)
+    [Create a check](/Data-insights/Features/Alerting/Alerts-overview/)
 
 #### Example billing usage checks
 
-For instructions on configuring billing checks, see the [Billing usage checks](/Data-insights/Features/billing-check) section. The following are examples of common billing usage checks: 
+For instructions on configuring billing checks, see the [Billing usage checks](/Data-insights/Features/alerting-examples/) section. The following are examples of common billing usage checks: 
 
 * `fr_billing_usage_current`
 * `fr_billing_charges_metered`

--- a/docs/Latest-updates/Releases.md
+++ b/docs/Latest-updates/Releases.md
@@ -34,7 +34,7 @@ Introducing OpsPilot Hub: Your centralized knowledge repository for enhanced ope
 
 
 !!! info "Learn more"
-    [OpsPilot Hub](/Data-insights/Features/OpsPilot/OpsPilot-Hub/overview/)
+    [OpsPilot Hub](/Data-insights/Features/OpsPilot/OpsPilot-Hub/Knowledge/)
 
 
 ### FusionReactor 12.1

--- a/docs/Latest-updates/WhatsNew.md
+++ b/docs/Latest-updates/WhatsNew.md
@@ -223,7 +223,7 @@ OpsPilot now integrates directly with Jira Cloud and Data Center, enabling you t
 ![!Screenshot](../../Latest-updates/images/Jira1.png)
 
 !!! info "Learn more"
-    [Jira integration](/Data-insights/Features/OpsPilot/OpsPilot-Hub/Jira/)
+    [Jira integration](/Data-insights/Features/OpsPilot/OpsPilot-Hub/Knowledge/)
 
 ## Explore: Servers 
 The new Servers tab in Explore provides enhanced server monitoring capabilities:
@@ -251,7 +251,7 @@ Introducing OpsPilot Hub: Your centralized knowledge repository for enhanced ope
 
 
 !!! info "Learn more"
-    [OpsPilot Hub](/Data-insights/Features/OpsPilot/OpsPilot-Hub/overview/)
+    [OpsPilot Hub](/Data-insights/Features/OpsPilot/OpsPilot-Hub/Knowledge/)
 
 ## FusionReactor 12.1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -501,7 +501,7 @@ hide:
 
 <div style="display: flex; flex-wrap: wrap; gap: 20px;">
 
-  <a href="/Data-insights/Features/alerting/" style="text-decoration: none; color: inherit; width: calc(25% - 20px);" class="doc-grid-item-link">
+  <a href="/Data-insights/Features/Alerting/Alerts-overview/" style="text-decoration: none; color: inherit; width: calc(25% - 20px);" class="doc-grid-item-link">
     <div style="
       border: 1px solid #ccc;
       padding: 12px;
@@ -846,7 +846,7 @@ hide:
   </a>
 
   
-  <a href="/Data-insights/Features/servers/" style="text-decoration: none; color: inherit; width: calc(25% - 20px);" class="doc-grid-item-link">
+  <a href="/Data-insights/Features/Explore-servers/" style="text-decoration: none; color: inherit; width: calc(25% - 20px);" class="doc-grid-item-link">
     <div style="
       border: 1px solid #ccc;
       padding: 12px;


### PR DESCRIPTION
- OpsPilot Hub Jira and overview → Knowledge page
- /Data-insights/Features/alerting/ → Alerting/Alerts-overview/
- /Data-insights/Features/servers/ → Explore-servers/
- /Data-insights/Features/billing-check → alerting-examples/
- alerting/#create-a-check → Alerting/Alerts-overview/